### PR TITLE
Fix issue where incoming integer param errors out constructor

### DIFF
--- a/lib/Datamatrix.php
+++ b/lib/Datamatrix.php
@@ -1160,6 +1160,28 @@ class Datamatrix
 		return $marr;
 	}
 
+	/**
+	 * Safely casts a variable to a string, unless it's an array, object, boolean, null, or empty.
+	 *
+	 * This function checks the type and content of the provided data. It returns false for null values,
+	 * booleans, arrays, objects, empty strings, or strings containing only a null character ('\0').
+	 * For other types (like integers, floats), or strings that do not fall into the above categories,
+	 * it casts them to a string and returns the result.
+	 *
+	 * @param mixed $code The variable to be cast to a string.
+	 * @return string|false Returns a string representation of the input data if it can be
+	 *                      safely converted to a string, or false otherwise.
+	 */
+	protected function safeStringCast($code) {
+		// Check for invalid values
+		if ((is_null($code)) OR ($code == '\0') OR ($code == '') OR is_bool($code) OR is_array($code) OR is_object($code)) {
+			return false;
+		}
+
+		// Default: cast to string for other types like integers, floats, etc.
+		return (string) $code;
+	}
+
 } // end DataMatrix class
 //============================================================+
 // END OF FILE

--- a/lib/Datamatrix.php
+++ b/lib/Datamatrix.php
@@ -225,6 +225,8 @@ class Datamatrix
 		if ((is_null($code)) OR ($code == '\0') OR ($code == '')) {
 			return false;
 		}
+		// Assert that $code is a string
+		$code = (string) $code;
 		// get data codewords
 		$cw = $this->getHighLevelEncoding($code);
 		// number of data codewords

--- a/lib/Datamatrix.php
+++ b/lib/Datamatrix.php
@@ -222,10 +222,11 @@ class Datamatrix
 	 */
 	public function __construct($code) {
 		$barcode_array = array();
-		if ((is_null($code)) OR ($code == '\0') OR ($code == '')) {
+		// assert that $code is a valid string
+		$code = $this->safeStringCast($code);
+		if (!$code) {
 			return false;
 		}
-		// Assert that $code is a string
 		$code = (string) $code;
 		// get data codewords
 		$cw = $this->getHighLevelEncoding($code);

--- a/lib/Datamatrix.php
+++ b/lib/Datamatrix.php
@@ -227,7 +227,6 @@ class Datamatrix
 		if (!$code) {
 			return false;
 		}
-		$code = (string) $code;
 		// get data codewords
 		$cw = $this->getHighLevelEncoding($code);
 		// number of data codewords


### PR DESCRIPTION
This PR adds a new function to validate the data type of incoming params for the Datamatrix constructor. The old checks and functionality are retained with additional checks for booleans, arrays and objects. If param is an integer or float, it is safely converted to a string before constructor continues.